### PR TITLE
support torch1.0

### DIFF
--- a/pytorch/torchsparseattn/base.py
+++ b/pytorch/torchsparseattn/base.py
@@ -27,7 +27,8 @@ class _BaseBatchProjection(ta.Function):
 
         if requires_squeeze:
             y_star = y_star.squeeze()
-
+ 
+        self.mark_non_differentiable(y_star)
         if has_lengths:
             self.save_for_backward(y_star, lengths)
         else:

--- a/pytorch/torchsparseattn/sparsemax.py
+++ b/pytorch/torchsparseattn/sparsemax.py
@@ -18,6 +18,7 @@ def project_simplex(v, z=1):
     v_sorted, _ = torch.sort(v, dim=0, descending=True)
     cssv = torch.cumsum(v_sorted, dim=0) - z
     ind = torch.arange(1, 1 + len(v))
+    ind = ind.type(torch.FloatTensor)
     cond = v_sorted - cssv / ind > 0
     rho = ind.masked_select(cond)[-1]
     tau = cssv.masked_select(cond)[-1] / rho


### PR DESCRIPTION
In the torch 1.0, if y_star is save_for_backward, then the retrieved tensor by saved_tensor becomes a Variable somehow, which means it will be destroyed immediately after one backward. Still not sure about the mechanism here.

So I add the function "self.mark_non_differentiable(y_star)" which works well to pass the test cases. 